### PR TITLE
Increase container width by 1px

### DIFF
--- a/src/coffee/bootstrap-switch.coffee
+++ b/src/coffee/bootstrap-switch.coffee
@@ -321,7 +321,7 @@ do ($ = window.jQuery, window) ->
       @_labelWidth = @$label.outerWidth()
 
       # set container and wrapper widths
-      @$container.width (@_handleWidth * 2) + @_labelWidth
+      @$container.width (@_handleWidth * 2) + @_labelWidth + 1
       @$wrapper.width @_handleWidth + @_labelWidth
 
     _containerPosition: (state = @options.state, callback) ->


### PR DESCRIPTION
Rounding errors on the element width sometimes causes the container to be 1px too small and the switch OFF element wraps to the next line.

See http://i.imgur.com/LeDpWCp.png for an example "in the wild". This is with Bootstrap Switch 3.3.2, Bootstrap SASS 3.2.0.2 and jQuery 2.1.3. I wasn't able to reproduce this issue on JSFiddle however.

Can you see any issues with simply increasing the container width by 1px?
